### PR TITLE
Feature/wall temp

### DIFF
--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -21,7 +21,8 @@ set(SOURCES FGAerodynamics.cpp
             FGExternalForce.cpp
             FGBuoyantForces.cpp
             FGGasCell.cpp
-            FGAccelerations.cpp)
+            FGAccelerations.cpp
+            DAWallTempEstimation.cpp)
 
 set(HEADERS FGAerodynamics.h
             FGAircraft.h
@@ -43,7 +44,8 @@ set(HEADERS FGAerodynamics.h
             FGBuoyantForces.h
             FGGasCell.h
             FGAccelerations.h
-            FGFCSChannel.h)
+            FGFCSChannel.h
+            DAWallTempEstimation.h)
 
 add_library(Models OBJECT ${HEADERS} ${SOURCES})
 set_target_properties(Models PROPERTIES TARGET_DIRECTORY

--- a/src/models/DAWallTempEstimation.cpp
+++ b/src/models/DAWallTempEstimation.cpp
@@ -48,7 +48,7 @@ namespace JSBSim {
       double gm;
       tie(cp, gm) = CalculateCpAndGamma(airTemp_K);
       double const Tref = 1.0 + a * pow(machSpeed, 2.0) + b * (estimate / airTemp_K - 1.0);
-      double const Pr = absoluteViscosity * cp / (2.64638e-3 * pow(airTemp_K, 1.5) / (airTemp_K + 245.0 * pow(10.0, (-12.0 / airTemp_K))));
+      double const Pr = absoluteViscosity * cp * (airTemp_K + 245.0 * pow(10.0, (-12.0 / airTemp_K)))/ (2.64638e-3 * pow(airTemp_K, 1.5));
       double const q = 0.5 * gm * airPressure_Pa * pow(machSpeed, 2.0);
       double const cf = cfi / (pow(Tref, NN));
       double const r = flowType_ == 0? pow(Pr, 0.5) : pow(Pr, (1.0 / 3.0));
@@ -63,7 +63,7 @@ namespace JSBSim {
       return balance;
     }
 
-    std::tuple<double, double> DAWallTempEstimation::CalculateCpAndGamma(double estimate) {
+    std::tuple<double, double> DAWallTempEstimation::CalculateCpAndGamma(double temperature) {
       vector<int> T_arr = {250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500};
       vector<double> cp_arr = {1.003, 1.005, 1.008, 1.013, 1.02, 1.029, 1.04, 1.051, 1.063, 1.075, 1.087, 1.099, 1.121, 1.142, 1.155,
               1.173, 1.19, 1.204, 1.216};
@@ -73,7 +73,7 @@ namespace JSBSim {
       double cv;
       int i = -1;
       for (int n =0; n< T_arr.size(); n++) {
-        if (estimate < T_arr[n]) {
+        if (temperature < T_arr[n]) {
           i = n;
           break;
         }
@@ -85,7 +85,7 @@ namespace JSBSim {
         cp = cp_arr[0];
         cv = cv_arr[0];
       } else {
-        double const fraction = (estimate - T_arr[i - 1]) / (T_arr[i] - T_arr[i - 1]);
+        double const fraction = (temperature - T_arr[i - 1]) / (T_arr[i] - T_arr[i - 1]);
         cp = cp_arr[i - 1] + fraction * (cp_arr[i] - cp_arr[i - 1]);
         cv = cv_arr[i - 1] + fraction * (cv_arr[i] - cv_arr[i - 1]);
       }

--- a/src/models/DAWallTempEstimation.cpp
+++ b/src/models/DAWallTempEstimation.cpp
@@ -1,0 +1,130 @@
+//
+// Created by caleb on 23/01/23.
+//
+#include "FGFDMExec.h"
+#include "DAWallTempEstimation.h"
+
+
+namespace JSBSim {
+
+    DAWallTempEstimation::DAWallTempEstimation(FGFDMExec* _fdmex){
+      fdmex_ = _fdmex;
+      atmosphere_ = fdmex_->GetAtmosphere();
+    }
+
+    double DAWallTempEstimation::GetWallTempEstimateCelsius(double _chord) {
+      chord_m = _chord * FEET_TO_METER_;
+      machSpeed = fdmex_->GetPropertyValue("velocities/mach");
+      machSpeed = machSpeed < 0.0001 ? 0.0001 : machSpeed;
+      airTemp_K = atmosphere_->GetTemperature() * RANKINE_TO_KELVIN_;
+      airPressure_Pa = atmosphere_->GetPressure() * PSF_TO_PASCAL_;
+      kinematicViscosity = atmosphere_->GetKinematicViscosity();
+      absoluteViscosity = atmosphere_->GetAbsoluteViscosity();
+      soundSpeed_ms = atmosphere_->GetSoundSpeed() * FEET_TO_METER_;
+      velocity_ms = machSpeed * soundSpeed_ms;
+      reynoldsNumber = velocity_ms * chord_m / kinematicViscosity;
+      if (flowType_ == 0) {
+        C = 0.664;
+        N = 0.5;
+        a = 0.032;
+        b = 0.58;
+      }
+      else {
+        C = 0.0592;
+        N = 0.2;
+        a = 0.035;
+        b = 0.45;
+      }
+      cfi = C / (pow(reynoldsNumber, N));
+      NN = 1 - N * (w + 1);
+      return DAWallTempEstimation::NewtonRaphson() + KELVIN_TO_CELSIUS_;
+    }
+
+    double DAWallTempEstimation::HeatBalance(double estimate) const {
+      double cp;
+      double gm;
+      tie(cp, gm) = CalculateCpAndGamma(airTemp_K);
+      double const Tref = 1 + a * pow(machSpeed, 2) + b * (estimate / airTemp_K - 1);
+      double const Pr = absoluteViscosity * cp / (2.64638e-3 * pow(airTemp_K, 1.5) / (airTemp_K + 245 * pow(10, (-12 / airTemp_K))));
+      double const q = 0.5 * gm * airPressure_Pa * pow(machSpeed, 2);
+      double const cf = cfi / (pow(Tref, NN));
+      double const r = flowType_ == 0? pow(Pr, 0.5) : pow(Pr, (1 / 3));
+      double const St = 0.5 * cf / pow(Pr, (2 / 3));
+      double const Twad = airTemp_K * (1 + 0.5 * r * (gm - 1) * pow(machSpeed, 2));
+      double const conducted = St * r * q * velocity_ms * (Twad - estimate) / (Twad - airTemp_K);
+      double radiated = 0;
+      if (machSpeed > 1.4) {
+        radiated = emissivity_ * sg * pow((estimate - airTemp_K), 4);
+      }
+      double const balance = conducted - radiated;
+      return balance;
+    }
+
+    std::tuple<double, double> DAWallTempEstimation::CalculateCpAndGamma(double estimate) {
+      vector<int> T_arr = {250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500};
+      vector<double> cp_arr = {1.003, 1.005, 1.008, 1.013, 1.02, 1.029, 1.04, 1.051, 1.063, 1.075, 1.087, 1.099, 1.121, 1.142, 1.155,
+              1.173, 1.19, 1.204, 1.216};
+      vector<double> cv_arr = {0.716, 0.718, 0.721, 0.726, 0.733, 0.742, 0.753, 0.764, 0.776, 0.788, 0.8, 0.812, 0.834, 0.855, 0.868,
+              0.886, 0.903, 0.917, 0.929};
+      double cp;
+      double cv;
+      int i = -1;
+      for (int n =0; n< T_arr.size(); n++) {
+        if (estimate < T_arr[n]) {
+          i = n;
+          break;
+        }
+      }
+      if (i == -1) {
+        cp = cp_arr[18];
+        cv = cv_arr[18];
+      }else if (i == 0){
+        cp = cp_arr[0];
+        cv = cv_arr[0];
+      } else {
+        double const fraction = (estimate - T_arr[i - 1]) / (T_arr[i] - T_arr[i - 1]);
+        cp = cp_arr[i - 1] + fraction * (cp_arr[i] - cp_arr[i - 1]);
+        cv = cv_arr[i - 1] + fraction * (cv_arr[i] - cv_arr[i - 1]);
+      }
+      cp = 1000 * cp;
+      cv = 1000 * cv;
+      double const gamma = cp / cv;
+      return {cp, gamma};
+    }
+
+    double DAWallTempEstimation::NewtonRaphson() {
+      double xs = startingGuess;
+      double x0;
+      double x1;
+      double f0;
+      double f1;
+      double df;
+      double fx;
+      for (int i=0; i < maxIterations; i++) {
+        x0 = xs - dx;
+        x1 = xs + dx;
+        f0 = HeatBalance(x0);
+        f1 = HeatBalance(x1);
+        df = f1 - f0;
+        df = 0.5 * df / dx;
+        fx = HeatBalance(xs);
+        if (abs(fx) < tol) {
+          break;
+        }
+        if (abs(df) < 1E-16) {
+          dx = 10 * dx;
+        } else {
+          xs = xs - fx / df;
+        }
+        if (xs < 10) {
+          xs = 10;
+          break;
+        }
+        if (xs > 1000){
+          xs = 1000;
+          break;
+        }
+      }
+      return xs;
+    }
+}

--- a/src/models/DAWallTempEstimation.h
+++ b/src/models/DAWallTempEstimation.h
@@ -1,0 +1,54 @@
+//
+// Created by caleb on 23/01/23.
+//
+
+#ifndef JSB_STATE_DAWALLTEMPESTIMATION_H
+#define JSB_STATE_DAWALLTEMPESTIMATION_H
+
+#include "FGFDMExec.h"
+#include "FGAtmosphere.h"
+
+namespace JSBSim {
+
+
+
+class DAWallTempEstimation {
+public:
+    explicit DAWallTempEstimation(JSBSim::FGFDMExec *_fdmex);
+    double GetWallTempEstimateCelsius(double chord);
+
+private:
+    FGFDMExec* fdmex_;
+    std::shared_ptr<FGAtmosphere> atmosphere_;
+
+    double HeatBalance(double estimate) const;
+    std::tuple<double, double> static CalculateCpAndGamma(double estimate);
+    double NewtonRaphson();
+
+    double machSpeed;
+    double chord_m;
+    double airTemp_K;
+    double airPressure_Pa;
+    double kinematicViscosity;
+    double absoluteViscosity;
+    double soundSpeed_ms;
+    double velocity_ms;
+    double reynoldsNumber;
+    double cfi, NN, C, N, a, b;
+
+    double startingGuess=500;
+    double tol=1E-2;
+    double dx=1E-1;
+    double maxIterations=30;
+    double w = 0.76;
+    double sg = 5.67E-8; //stefan-boltzmann constant
+    double emissivity_ = 0.9; //emissivity anodised aluminum or white paint or black paint
+    int flowType_ = 1; //flow type: 0 = laminar, 1 = turbulent
+
+    double KELVIN_TO_CELSIUS_ = -273.15;
+    double FEET_TO_METER_ = 0.3048;
+    double RANKINE_TO_KELVIN_ = 1/1.8;
+    double PSF_TO_PASCAL_ = 47.880208;
+};
+}
+#endif //JSB_STATE_DAWALLTEMPESTIMATION_H

--- a/src/models/DAWallTempEstimation.h
+++ b/src/models/DAWallTempEstimation.h
@@ -14,40 +14,46 @@ namespace JSBSim {
 
 class DAWallTempEstimation {
 public:
-    explicit DAWallTempEstimation(JSBSim::FGFDMExec *_fdmex);
-    double GetWallTempEstimateCelsius(double chord);
+    DAWallTempEstimation() {};
+    DAWallTempEstimation(JSBSim::FGFDMExec *_fdmex);
+    double GetWallTempEstimateCelsius(double chord, double _machSpeed);
 
-private:
-    FGFDMExec* fdmex_;
+protected:
     std::shared_ptr<FGAtmosphere> atmosphere_;
-
-    double HeatBalance(double estimate) const;
-    std::tuple<double, double> static CalculateCpAndGamma(double estimate);
-    double NewtonRaphson();
-
-    double machSpeed;
     double chord_m;
+    double machSpeed;
     double airTemp_K;
     double airPressure_Pa;
     double kinematicViscosity;
     double absoluteViscosity;
     double soundSpeed_ms;
+    double maxIterations=30;
+    int flowType_ = 1; //flow type: 0 = laminar, 1 = turbulent
+    virtual void SetInputs();
+
+    double HeatBalance(double estimate) const;
+    std::tuple<double, double> static CalculateCpAndGamma(double estimate);
+    double NewtonRaphson();
+
+private:
+    FGFDMExec* fdmex_;
     double velocity_ms;
     double reynoldsNumber;
     double cfi, NN, C, N, a, b;
 
     double startingGuess=500;
-    double tol=1E-2;
+    double tol_fx=1E-2;
+    double tol_df=1E-16;
     double dx=1E-1;
-    double maxIterations=30;
+    int xMin = 10;
+    int xMax = 10000;
     double w = 0.76;
     double sg = 5.67E-8; //stefan-boltzmann constant
     double emissivity_ = 0.9; //emissivity anodised aluminum or white paint or black paint
-    int flowType_ = 1; //flow type: 0 = laminar, 1 = turbulent
 
     double KELVIN_TO_CELSIUS_ = -273.15;
     double FEET_TO_METER_ = 0.3048;
-    double RANKINE_TO_KELVIN_ = 1/1.8;
+    double RANKINE_TO_KELVIN_ = 1.0/1.8;
     double PSF_TO_PASCAL_ = 47.880208;
 };
 }

--- a/src/models/DAWallTempEstimation.h
+++ b/src/models/DAWallTempEstimation.h
@@ -32,7 +32,7 @@ protected:
     virtual void SetInputs();
 
     double HeatBalance(double estimate) const;
-    std::tuple<double, double> static CalculateCpAndGamma(double estimate);
+    std::tuple<double, double> static CalculateCpAndGamma(double temperature);
     double NewtonRaphson();
 
 private:

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -173,7 +173,7 @@ bool FGAircraft::Load(Element* el)
 
 double FGAircraft::CalculateLeadingEdgeTemp()
 {
-  leadingEdgeTemp = tempEstimator.GetWallTempEstimateCelsius(cbar);
+  leadingEdgeTemp = tempEstimator.GetWallTempEstimateCelsius(cbar, FDMExec->GetPropertyValue("velocities/mach"));
   return leadingEdgeTemp;
 }
 

--- a/src/models/FGAircraft.cpp
+++ b/src/models/FGAircraft.cpp
@@ -49,7 +49,7 @@ namespace JSBSim {
 CLASS IMPLEMENTATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
-FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex)
+FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex), tempEstimator(DAWallTempEstimation(fdmex))
 {
   Name = "FGAircraft";
   WingSpan = 0.0;
@@ -60,7 +60,6 @@ FGAircraft::FGAircraft(FGFDMExec* fdmex) : FGModel(fdmex)
   lbarh = lbarv = 0.0;
   vbarh = vbarv = 0.0;
   WingIncidence = 0.0;
-
   bind();
 
   Debug(0);
@@ -105,6 +104,8 @@ bool FGAircraft::Run(bool Holding)
   vMoments += in.GroundMoment;
   vMoments += in.ExternalMoment;
   vMoments += in.BuoyantMoment;
+
+  CalculateLeadingEdgeTemp();
 
   RunPostFunctions();
 
@@ -168,6 +169,14 @@ bool FGAircraft::Load(Element* el)
   return true;
 }
 
+
+
+double FGAircraft::CalculateLeadingEdgeTemp()
+{
+  leadingEdgeTemp = tempEstimator.GetWallTempEstimateCelsius(cbar);
+  return leadingEdgeTemp;
+}
+
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 void FGAircraft::bind(void)
@@ -186,6 +195,7 @@ void FGAircraft::bind(void)
   PropertyManager->Tie("metrics/lv-norm", this, &FGAircraft::Getlbarv);
   PropertyManager->Tie("metrics/vbarh-norm", this, &FGAircraft::Getvbarh);
   PropertyManager->Tie("metrics/vbarv-norm", this, &FGAircraft::Getvbarv);
+  PropertyManager->Tie("metrics/leadingEdgeTemp-cel", this, &FGAircraft::GetLeadingEdgeTemp);
   PropertyManager->Tie("metrics/aero-rp-x-in", this, eX, (PMF)&FGAircraft::GetXYZrp, &FGAircraft::SetXYZrp);
   PropertyManager->Tie("metrics/aero-rp-y-in", this, eY, (PMF)&FGAircraft::GetXYZrp, &FGAircraft::SetXYZrp);
   PropertyManager->Tie("metrics/aero-rp-z-in", this, eZ, (PMF)&FGAircraft::GetXYZrp, &FGAircraft::SetXYZrp);

--- a/src/models/FGAircraft.h
+++ b/src/models/FGAircraft.h
@@ -42,6 +42,7 @@ INCLUDES
 
 #include "FGModel.h"
 #include "math/FGMatrix33.h"
+#include "DAWallTempEstimation.h"
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 FORWARD DECLARATIONS
@@ -110,7 +111,7 @@ public:
 
   /** Runs the Aircraft model; called by the Executive
       Can pass in a value indicating if the executive is directing the simulation to Hold.
-      @param Holding if true, the executive has been directed to hold the sim from 
+      @param Holding if true, the executive has been directed to hold the sim from
                      advancing time. Some models may ignore this flag, such as the Input
                      model, which may need to be active to listen on a socket for the
                      "Resume" command to be given.
@@ -150,6 +151,7 @@ public:
   double GetMoments(int idx) const { return vMoments(idx); }
   const FGColumnVector3& GetForces(void) const { return vForces; }
   double GetForces(int idx) const { return vForces(idx); }
+  double GetLeadingEdgeTemp() const {return leadingEdgeTemp;}
   /** Gets the the aero reference point (RP) coordinates.
       @return a vector containing the RP coordinates in the structural frame. */
   const FGColumnVector3& GetXYZrp(void) const { return vXYZrp; }
@@ -163,6 +165,8 @@ public:
   void SetXYZrp(int idx, double value) {vXYZrp(idx) = value;}
 
   void SetWingArea(double S) {WingArea = S;}
+
+  double CalculateLeadingEdgeTemp();
 
   struct Inputs {
     FGColumnVector3 AeroForce;
@@ -188,7 +192,9 @@ private:
   double WingArea, WingSpan, cbar, WingIncidence;
   double HTailArea, VTailArea, HTailArm, VTailArm;
   double lbarh,lbarv,vbarh,vbarv;
+  double leadingEdgeTemp;
   std::string AircraftName;
+  DAWallTempEstimation tempEstimator;
 
   void bind(void);
   void unbind(void);

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -17,7 +17,8 @@ set(UNIT_TESTS FGColumnVector3Test
                FGParameterTest
                FGParameterValueTest
                FGConditionTest
-               FGPropertyManagerTest)
+               FGPropertyManagerTest
+               DAWallTempEstimationTest)
 
 foreach(test ${UNIT_TESTS})
   cxxtest_add_test(${test}1 ${test}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${test}.h)

--- a/tests/unit_tests/DAWallTempEstimationTest.h
+++ b/tests/unit_tests/DAWallTempEstimationTest.h
@@ -24,9 +24,14 @@ private:
     double _soundSpeed_ms;
     int _maxIterations=30;
     
-    double METER_TO_FEET_ = 1.0/0.3048;
+    double METER_TO_FEET_ = 1/0.3048;
     double KELVIN_TO_RANKINE_ = 1.8;
-    double PASCAL_TO_PSF_ = 1.0/47.880208;
+    double PASCAL_TO_PSF_ = 1/47.880208;
+
+    double FEET_TO_METER_ = 0.3048;
+    double RANKINE_TO_KELVIN_ = 1/1.8;
+    double PSF_TO_PASCAL_ = 47.880208;
+
 
     void setupTest() {
       DAWallTempEstimation();
@@ -78,7 +83,7 @@ public:
       _soundSpeed_ms = 299.4659948926586 * METER_TO_FEET_;
       setupTest();
       flowType_ = 1;
-      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,1)), -10);
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1 * METER_TO_FEET_,1)), -10);
     }
 
     // Mach 1 at 10k laminar flow
@@ -90,7 +95,7 @@ public:
       _soundSpeed_ms = 299.4659948926586 * METER_TO_FEET_;
       setupTest();
       flowType_ = 0;
-      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,1)), -12);
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1 * METER_TO_FEET_,1)), -12);
     }
 
     // Mach 2.04 at 18.3k turbulent flow
@@ -102,7 +107,7 @@ public:
       _soundSpeed_ms = 295.0722820056179 * METER_TO_FEET_;
       setupTest();
       flowType_ = 1;
-      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,2.04)), 106);
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1 * METER_TO_FEET_,2.04)), 106);
     }
 
     // Mach 3.1 at 25k turbulent flow
@@ -114,7 +119,7 @@ public:
       _soundSpeed_ms = 298.4578021705926 * METER_TO_FEET_;
       setupTest();
       flowType_ = 1;
-      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,3.1)), 326);
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1 * METER_TO_FEET_,3.1)), 326);
     }
 
     // Mach 4 at 30k turbulent flow
@@ -126,44 +131,44 @@ public:
       _soundSpeed_ms = 301.8053474426823 * METER_TO_FEET_;
       setupTest();
       flowType_ = 1;
-      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,4.0)), 579);
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1 * METER_TO_FEET_,4.0)), 579);
     }
 
     //Mach speed of 0 breaks calc with zero division, 0.0001Ma = 0.12348kph
     void testMinMachSpeed() {
       setupTest();
       maxIterations=0;
-      GetWallTempEstimateCelsius(1.08,0);
+      GetWallTempEstimateCelsius(1,0);
       TS_ASSERT_EQUALS(machSpeed, 0.0001);
     }
 
     void testRegularMachSpeed() {
       setupTest();
       maxIterations=0;
-      GetWallTempEstimateCelsius(1.08,1.4);
+      GetWallTempEstimateCelsius(1,1.4);
       TS_ASSERT_EQUALS(machSpeed, 1.4);
     }
 
     void testChordConversion() {
       setupTest();
       maxIterations=0;
-      GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,1);
-      TS_ASSERT_EQUALS(chord_m, 1.08);
+      GetWallTempEstimateCelsius(1 * METER_TO_FEET_,1);
+      TS_ASSERT_EQUALS(round(chord_m), 1.0);
     }
 
     void testSetInputs() {
-      _airTemp_K = 216.65/(1.0/KELVIN_TO_RANKINE_); // Messy Math but else it fails
-      _airPressure_Pa = 7158.118362641401 * PASCAL_TO_PSF_;
-      _kinematicViscosity = 0.00012351261888837405;
-      _absoluteViscosity = 1.4216130796413358e-05;
-      _soundSpeed_ms = 295.0722820056179/(1.0/METER_TO_FEET_); // Messy Math but else it fails
+      _airTemp_K = 216.0 * KELVIN_TO_RANKINE_;
+      _airPressure_Pa = 7158.0 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 0.0001;
+      _absoluteViscosity = 1.4e-05;
+      _soundSpeed_ms = 295.0 * FEET_TO_METER_;
       setupTest();
       SetInputs();
-      TS_ASSERT_EQUALS(airTemp_K, 216.65);
-      TS_ASSERT_EQUALS(airPressure_Pa, 7158.118362641401);
+      TS_ASSERT_EQUALS(airTemp_K, _airTemp_K * RANKINE_TO_KELVIN_);
+      TS_ASSERT_EQUALS(airPressure_Pa, _airPressure_Pa * PSF_TO_PASCAL_);
       TS_ASSERT_EQUALS(kinematicViscosity, _kinematicViscosity);
       TS_ASSERT_EQUALS(absoluteViscosity, _absoluteViscosity);
-      TS_ASSERT_EQUALS(soundSpeed_ms, _soundSpeed_ms / METER_TO_FEET_);
+      TS_ASSERT_EQUALS(soundSpeed_ms, _soundSpeed_ms * FEET_TO_METER_);
     }
 
     void testCalculateCpAndGammaWithTempBelow250() {

--- a/tests/unit_tests/DAWallTempEstimationTest.h
+++ b/tests/unit_tests/DAWallTempEstimationTest.h
@@ -1,0 +1,194 @@
+//
+// Created by caleb on 1/02/23.
+//
+
+#ifndef JSBSIM_DAWALLTEMPESTIMATIONTEST_H
+#define JSBSIM_DAWALLTEMPESTIMATIONTEST_H
+
+#include <cxxtest/TestSuite.h>
+#include "FGFDMExec.h"
+#include "models/atmosphere/FGStandardAtmosphere.h"
+#include "models/DAWallTempEstimation.h"
+
+
+using namespace JSBSim;
+
+
+class DAWallTempEstimationTest : public CxxTest::TestSuite, public JSBSim::DAWallTempEstimation{
+private:
+    JSBSim::FGFDMExec FDMExec;
+    double _airTemp_K;
+    double _airPressure_Pa;
+    double _kinematicViscosity;
+    double _absoluteViscosity;
+    double _soundSpeed_ms;
+    int _maxIterations=30;
+    
+    double METER_TO_FEET_ = 1.0/0.3048;
+    double KELVIN_TO_RANKINE_ = 1.8;
+    double PASCAL_TO_PSF_ = 1.0/47.880208;
+
+    void setupTest() {
+      DAWallTempEstimation();
+      MockAtmosphere mockAtmosphere = MockAtmosphere(&FDMExec);
+      maxIterations=_maxIterations;
+      mockAtmosphere.SetTemperature(_airTemp_K);
+      mockAtmosphere.SetPressure(_airPressure_Pa);
+      mockAtmosphere.SetKinematicViscosity(_kinematicViscosity);
+      mockAtmosphere.SetAbsoluteViscosity(_absoluteViscosity);
+      mockAtmosphere.SetSoundSpeed(_soundSpeed_ms);
+      atmosphere_ = std::make_shared<MockAtmosphere>(mockAtmosphere);
+    }
+
+    class MockAtmosphere: public FGStandardAtmosphere {
+    public:
+        double airTemp_K;
+        double airPressure_Pa;
+        double kinematicViscosity;
+        double absoluteViscosity;
+        double soundSpeed_ms;
+        MockAtmosphere(FGFDMExec* fdmex)
+                : FGStandardAtmosphere(fdmex){};
+        virtual double GetTemperature() const override {return airTemp_K;}
+        virtual double GetPressure() const override {return airPressure_Pa;}
+        virtual double GetKinematicViscosity() const override {return kinematicViscosity;}
+        virtual double GetAbsoluteViscosity() const override {return absoluteViscosity;}
+        virtual double GetSoundSpeed() const override {return soundSpeed_ms;}
+        void SetTemperature(double value) {airTemp_K = value;}
+        void SetPressure(double value) {airPressure_Pa = value;}
+        void SetKinematicViscosity(double value) { kinematicViscosity = value;}
+        void SetAbsoluteViscosity(double value) {absoluteViscosity = value;}
+        void SetSoundSpeed(double value) {soundSpeed_ms = value;}
+    };
+
+public:
+
+    void testMockAtmosphereOverride() {
+      _airTemp_K = 5;
+      setupTest();
+      TS_ASSERT_EQUALS(atmosphere_->GetTemperature(), 5);
+    }
+
+    // Mach 1 at 10k turbulent flow
+    void testGetWallTempEstimateCelsiusMach1Alt10k() {
+      _airTemp_K = 223.14999999999998 * KELVIN_TO_RANKINE_;
+      _airPressure_Pa = 388349.24720240704 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 2.4034574673532144e-06;
+      _absoluteViscosity = 1.45710858090486e-05;
+      _soundSpeed_ms = 299.4659948926586 * METER_TO_FEET_;
+      setupTest();
+      flowType_ = 1;
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,1)), -10);
+    }
+
+    // Mach 1 at 10k laminar flow
+    void testGetWallTempEstimateCelsiusMach1Alt10kLaminarFlow() {
+      _airTemp_K = 223.14999999999998 * KELVIN_TO_RANKINE_;
+      _airPressure_Pa = 388349.24720240704 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 2.4034574673532144e-06;
+      _absoluteViscosity = 1.45710858090486e-05;
+      _soundSpeed_ms = 299.4659948926586 * METER_TO_FEET_;
+      setupTest();
+      flowType_ = 0;
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,1)), -12);
+    }
+
+    // Mach 2.04 at 18.3k turbulent flow
+    void testGetWallTempEstimateCelsiusMach2Alt18k() {
+      _airTemp_K = 216.65 * KELVIN_TO_RANKINE_;
+      _airPressure_Pa = 7158.118362641401 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 0.00012351261888837405;
+      _absoluteViscosity = 1.4216130796413358e-05;
+      _soundSpeed_ms = 295.0722820056179 * METER_TO_FEET_;
+      setupTest();
+      flowType_ = 1;
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,2.04)), 106);
+    }
+
+    // Mach 3.1 at 25k turbulent flow
+    void testGetWallTempEstimateCelsiusMach3Alt25k() {
+      _airTemp_K = 221.65 * KELVIN_TO_RANKINE_;
+      _airPressure_Pa = 11936.585391666198 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 7.723486130952107e-05;
+      _absoluteViscosity = 1.4489574855925882e-05;
+      _soundSpeed_ms = 298.4578021705926 * METER_TO_FEET_;
+      setupTest();
+      flowType_ = 1;
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,3.1)), 326);
+    }
+
+    // Mach 4 at 30k turbulent flow
+    void testGetWallTempEstimateCelsiusMach4Alt30k() {
+      _airTemp_K = 226.65 * KELVIN_TO_RANKINE_;
+      _airPressure_Pa = 25576.828953634504 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 3.7547057144736505e-05;
+      _absoluteViscosity = 1.47603541438064e-05;
+      _soundSpeed_ms = 301.8053474426823 * METER_TO_FEET_;
+      setupTest();
+      flowType_ = 1;
+      TS_ASSERT_EQUALS(round(GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,4.0)), 579);
+    }
+
+    //Mach speed of 0 breaks calc with zero division, 0.0001Ma = 0.12348kph
+    void testMinMachSpeed() {
+      setupTest();
+      maxIterations=0;
+      GetWallTempEstimateCelsius(1.08,0);
+      TS_ASSERT_EQUALS(machSpeed, 0.0001);
+    }
+
+    void testRegularMachSpeed() {
+      setupTest();
+      maxIterations=0;
+      GetWallTempEstimateCelsius(1.08,1.4);
+      TS_ASSERT_EQUALS(machSpeed, 1.4);
+    }
+
+    void testChordConversion() {
+      setupTest();
+      maxIterations=0;
+      GetWallTempEstimateCelsius(1.08 * METER_TO_FEET_,1);
+      TS_ASSERT_EQUALS(chord_m, 1.08);
+    }
+
+    void testSetInputs() {
+      _airTemp_K = 216.65/(1.0/KELVIN_TO_RANKINE_); // Messy Math but else it fails
+      _airPressure_Pa = 7158.118362641401 * PASCAL_TO_PSF_;
+      _kinematicViscosity = 0.00012351261888837405;
+      _absoluteViscosity = 1.4216130796413358e-05;
+      _soundSpeed_ms = 295.0722820056179/(1.0/METER_TO_FEET_); // Messy Math but else it fails
+      setupTest();
+      SetInputs();
+      TS_ASSERT_EQUALS(airTemp_K, 216.65);
+      TS_ASSERT_EQUALS(airPressure_Pa, 7158.118362641401);
+      TS_ASSERT_EQUALS(kinematicViscosity, _kinematicViscosity);
+      TS_ASSERT_EQUALS(absoluteViscosity, _absoluteViscosity);
+      TS_ASSERT_EQUALS(soundSpeed_ms, _soundSpeed_ms / METER_TO_FEET_);
+    }
+
+    void testCalculateCpAndGammaWithTempBelow250() {
+      double cp;
+      double gm;
+      tie(cp, gm) = CalculateCpAndGamma(250);
+      TS_ASSERT_EQUALS(round(cp), 1003);
+      TS_ASSERT_EQUALS(gm, 1.003/0.716);
+    }
+
+    void testCalculateCpAndGammaWithTempInRange() {
+      double cp;
+      double gm;
+      tie(cp, gm) = CalculateCpAndGamma(600);
+      TS_ASSERT_EQUALS(cp, 1051);
+      TS_ASSERT_EQUALS(gm, 1.051/0.764);
+    }
+
+    void testCalculateCpAndGammaWithTempAbove1500() {
+      double cp;
+      double gm;
+      tie(cp, gm) = CalculateCpAndGamma(1600);
+      TS_ASSERT_EQUALS(cp, 1216);
+      TS_ASSERT_EQUALS(gm, 1.216/0.929);
+    }
+};
+
+#endif //JSBSIM_DAWALLTEMPESTIMATIONTEST_H


### PR DESCRIPTION
Add class that calculates the wall temperature of the aircraft during each step iteration. Calculation based on existing python script and using Newton Raphson method. The calculated value is used to give an approximation of heating during reentry. Inputs are taken from the simulator where possible, such as temperature, density and speed of sound. Aircraft inputs include mach speed and Chord.  