### PR TITLE
Feature/expose quaternion elements

### DIFF
--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -882,10 +882,10 @@ void FGPropagate::bind(void)
   PropertyManager->Tie("attitude/pitch-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
   PropertyManager->Tie("attitude/heading-true-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
 
-  PropertyManager->Tie("attitude/quaternion-0", this, 1, (PMF)&FGPropagate::GetQuaternion);
-  PropertyManager->Tie("attitude/quaternion-1", this, 2, (PMF)&FGPropagate::GetQuaternion);
-  PropertyManager->Tie("attitude/quaternion-2", this, 3, (PMF)&FGPropagate::GetQuaternion);
-  PropertyManager->Tie("attitude/quaternion-3", this, 4, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/local-quaternion-0", this, 1, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/local-quaternion-1", this, 2, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/local-quaternion-2", this, 3, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/local-quaternion-3", this, 4, (PMF)&FGPropagate::GetQuaternion);
 
   PropertyManager->Tie("orbital/specific-angular-momentum-ft2_sec", &h);
   PropertyManager->Tie("orbital/inclination-deg", &Inclination);

--- a/src/models/FGPropagate.cpp
+++ b/src/models/FGPropagate.cpp
@@ -882,6 +882,11 @@ void FGPropagate::bind(void)
   PropertyManager->Tie("attitude/pitch-rad", this, (int)eTht, (PMF)&FGPropagate::GetEuler);
   PropertyManager->Tie("attitude/heading-true-rad", this, (int)ePsi, (PMF)&FGPropagate::GetEuler);
 
+  PropertyManager->Tie("attitude/quaternion-0", this, 1, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/quaternion-1", this, 2, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/quaternion-2", this, 3, (PMF)&FGPropagate::GetQuaternion);
+  PropertyManager->Tie("attitude/quaternion-3", this, 4, (PMF)&FGPropagate::GetQuaternion);
+
   PropertyManager->Tie("orbital/specific-angular-momentum-ft2_sec", &h);
   PropertyManager->Tie("orbital/inclination-deg", &Inclination);
   PropertyManager->Tie("orbital/right-ascension-deg", &RightAscension);

--- a/src/models/FGPropagate.h
+++ b/src/models/FGPropagate.h
@@ -410,6 +410,16 @@ public:
   */
   double GetSinEuler(int idx) const { return VState.qAttitudeLocal.GetSinEuler(idx); }
 
+  /** Retrieves an element of the vehicle Quaternion vector.
+      Retrieves an element of the quaternion that stores the vehicle orientation 
+      relative to the Local frame. The relevant arguments for the elements returned 
+      by this call are the elements of the vector starting at index 1 
+      (e.g. q0=1, q1=2, q2=3, q2=4).
+      units radians
+      @return An Quaternion element.
+  */
+  double GetQuaternion(int idx) const { return VState.qAttitudeLocal.Entry(idx); }
+
   /** Returns the current altitude rate.
       Returns the current altitude rate (rate of climb).
       units ft/sec

--- a/src/models/FGPropagate.h
+++ b/src/models/FGPropagate.h
@@ -415,8 +415,7 @@ public:
       relative to the Local frame. The relevant arguments for the elements returned 
       by this call are the elements of the vector starting at index 1 
       (e.g. q0=1, q1=2, q2=3, q2=4).
-      units radians
-      @return An Quaternion element.
+      @return A Quaternion element.
   */
   double GetQuaternion(int idx) const { return VState.qAttitudeLocal.Entry(idx); }
 


### PR DESCRIPTION
Expose the elements of the quaternion vector of the vehicle in the Property Manager.

Just used the vector index as the property name but happy to change to something a bit more specific if it gives more clarity.