### PR TITLE
* Private -> protected of fgexec

### DIFF
--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -612,7 +612,7 @@ public:
 
   auto GetRandomGenerator(void) const { return RandomGenerator; }
 
-private:
+protected:
   unsigned int Frame;
   unsigned int IdFDM;
   int disperse;


### PR DESCRIPTION
Change private to protected to allow usage of FgExec as a base. This enables us to build rotational and translational simulators by using FgExec as a base and override the LoadInputs function. We retain the same interface and can use the same models.