### PR TITLE
virtual load input function

### DIFF
--- a/src/FGFDMExec.h
+++ b/src/FGFDMExec.h
@@ -685,7 +685,7 @@ protected:
   bool ReadPrologue(Element*);
   void SRand(int sr);
   int  SRand(void) const {return RandomSeed;}
-  void LoadInputs(unsigned int idx);
+  virtual void LoadInputs(unsigned int idx);
   void LoadPlanetConstants(void);
   void LoadModelConstants(void);
   bool Allocate(void);


### PR DESCRIPTION
load_inputs needs to be overwritten for the rotational and translational simulator. Should have no effect on the 6DOF simulator.